### PR TITLE
Fix unit tests

### DIFF
--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -3,6 +3,9 @@ require 'cocoapods-amimono/integrator'
 
 Pod::HooksManager.register('cocoapods-amimono', :post_install) do |installer_context|
   # Find the aggregated target
+  # This is probably wrong, all agregated targets are prefixed by 'Pods-'
+  # but this works for now because find will return the first one
+  # which is usually the app target
   pods_target = installer_context.umbrella_targets.find do |target|
     target.cocoapods_target_label.include? 'Pods'
   end


### PR DESCRIPTION
This PR changes the filelist generation script to consider only the object files from direct dependencies and not all object files that it could find. In case of compiling unit tests, the test Pods are also in the same location therefore Xcode tries to static link these into the app binary.