### PR TITLE
Add vendored build settings patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add the following to your `post_install` hook:
 ```ruby
 post_install do |installer|
   require 'cocoapods-amimono/patcher'
-  Amimono::Patcher.patch_copy_resources_script(installer: installer)
+  Amimono::Patcher.patch!(installer: installer)
   ...
 ```
 


### PR DESCRIPTION
This should solve https://github.com/Ruenzuo/cocoapods-amimono/issues/8

Some Pods specify custom build settings which are only added to the CocoaPods aggregate target xcconfigs if the Pods are compiled from source and the Podfile doesn't use frameworks (see [here](https://github.com/CocoaPods/CocoaPods/blob/e5afc825eeafa60933a1299f52eb764c267cc9b2/lib/cocoapods/generator/xcconfig/aggregate_xcconfig.rb#L143-L158)). Amimono statically links Pods, so these build settings should be respected.