### PR TITLE
Add check for build directory before searching for o files

### DIFF
--- a/lib/cocoapods-amimono/integrator.rb
+++ b/lib/cocoapods-amimono/integrator.rb
@@ -7,11 +7,14 @@ module Amimono
             cd "$OBJROOT/Pods.build"
             filelist=""
             for dependency in "${DEPENDENCIES[@]}"; do
-              path="${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}/${dependency}.build/Objects-normal/${ARCH}/*.o"
-              for obj_file in $path; do
-                filelist+="${OBJROOT}/Pods.build/${obj_file}"
-                filelist+=$'\\n'
-              done
+              path="${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}/${dependency}.build/Objects-normal/${ARCH}"
+              if [ -d "$path" ]; then
+                search_path="$path/*.o"
+                for obj_file in $search_path; do
+                  filelist+="${OBJROOT}/Pods.build/${obj_file}"
+                  filelist+=$'\\n'
+                done
+              fi
             done
             filelist=${filelist\%$'\\n'}
             echo "$filelist" > "${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCH}.objects.filelist"


### PR DESCRIPTION
This should solve https://github.com/Ruenzuo/cocoapods-amimono/issues/10

It is possible to have Pods with only header files, these Pods will obviously not compiled so we should check if a build directory exist before searching for o files.

Some takeaways during the development of this: maybe this kind of Pods shouldn't even be supported by the plugin. The main problem here is that the support produces edge cases like: if the only Pod specified by a target is one of these kind, it doesn't even make sense to process that target at all. This check can't be done through the [plugin interface](https://github.com/Ruenzuo/cocoapods-amimono/blob/master/lib/cocoapods_plugin.rb#L4), because the information about if a Pod should be build is missing there. Maybe we should move all processing to [`post_install` hook in the Podfile](https://github.com/Ruenzuo/cocoapods-amimono/blob/master/lib/cocoapods-amimono/patcher.rb), which is the only place where the plugin can make those sort of decisions. I decided against moving it for now.