### PR TITLE
Fix generating dependency graph

### DIFF
--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -11,7 +11,7 @@ Pod::HooksManager.register('cocoapods-amimono', :post_install) do |installer_con
     target_info[pods_target] = installer_context.sandbox.target_support_files_dir pods_target.cocoapods_target_label
   end
 
-  integrator = Amimono::Integrator.new
+  integrator = Amimono::Integrator.new(installer_context)
   target_info.each do |pods_target, path|
     integrator.update_xcconfigs(aggregated_target_sandbox_path: path)
     puts "[Amimono] xcconfigs updated with filelist for target #{pods_target.cocoapods_target_label}"


### PR DESCRIPTION
The dependency graph generated was incorrect, it was missing some dependencies in our main target as well as in our WatchKit extension target.

Before:

```
App:
declare -a DEPENDENCIES=('1PasswordExtension' 'Adjust' 'Aspects' 'Crashlytics' 'EBKFontello' 'EBKImagePickerViewController' 'EBKInfiniteScrollController' 'FLAnimatedImage' 'Fabric' 'Google-Mobile-Ads-SDK' 'GoogleAnalytics' 'GoogleAppIndexing' 'HexColors' 'NYTPhotoViewer' 'OCMock' 'Objection' 'Optimizely-iOS-SDK' 'PPTopMostController' 'RFMAdSDK' 'Reveal-iOS-SDK' 'SSCWhatsAppActivity' 'SimulatorStatusMagic' 'TEDLocalization' 'TSMessages' 'Tweaks' 'UICKeyChainStore' 'VTAcknowledgementsViewController' 'apptentive-ios');

WatchKit extension:
declare -a DEPENDENCIES=();
```

After:

```
App:
declare -a DEPENDENCIES=('1PasswordExtension' 'AFNetworking-iOS' 'Adjust' 'Aspects' 'BlocksKit' 'EBKAPI-Core-Dependencies' 'EBKFontello' 'EBKImagePickerViewController' 'EBKInfiniteScrollController' 'FLAnimatedImage' 'HexColors' 'NYTPhotoViewer' 'OCMock' 'OHHTTPStubs' 'Objection' 'PPTopMostController' 'SSCWhatsAppActivity' 'SimulatorStatusMagic' 'TEDLocalization' 'TSMessages' 'Tweaks' 'UICKeyChainStore' 'VTAcknowledgementsViewController' 'apptentive-ios' 'libextobjc-iOS');

WatchKit extension:
declare -a DEPENDENCIES=('AFNetworking-watchOS' 'EBKAPI-Dependencies-Watch' 'libextobjc-watchOS');
```

Missing dependencies lead to crashes during runtime, whenever the missing symbols are accessed first. This is a high risk, probably it would be a good idea to write a Unit Tests in our projects, which are poking around in the symbols integrated via CocoaPods :).