### PR TITLE
Add support for binary static frameworks

### DIFF
--- a/lib/cocoapods-amimono/xcconfig_updater.rb
+++ b/lib/cocoapods-amimono/xcconfig_updater.rb
@@ -1,0 +1,28 @@
+module Amimono
+  class XCConfigUpdater
+    attr_reader :installer
+
+    def initialize(installer)
+      @installer = installer
+    end
+
+    def update_xcconfigs(aggregated_target, aggregated_target_sandbox_path)
+      path = aggregated_target_sandbox_path
+      archs = ['armv7', 'armv7s', 'arm64', 'i386', 'x86_64']
+      # Find all xcconfigs for the aggregated target
+      Dir.entries(path).select { |entry| entry.end_with? 'xcconfig' }.each do |entry|
+        full_path = path + entry
+        xcconfig = Xcodeproj::Config.new full_path
+        # Clear the -frameworks flag
+        xcconfig.other_linker_flags[:frameworks] = Set.new(aggregated_target.pod_targets.reject(&:should_build?).map(&:name))
+        # Add -filelist flag instead, for each architecture
+        archs.each do |arch|
+          config_key = "OTHER_LDFLAGS[arch=#{arch}]"
+          xcconfig.attributes[config_key] = "$(inherited) -filelist \"$(OBJROOT)/Pods.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)-$(TARGET_NAME)-#{arch}.objects.filelist\""
+        end
+        xcconfig.save_as full_path
+      end
+    end
+
+  end
+end

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -1,20 +1,10 @@
 require 'cocoapods-amimono/command'
-require 'cocoapods-amimono/integrator'
+require 'cocoapods-amimono/build_phases_updater'
 
 Pod::HooksManager.register('cocoapods-amimono', :post_install) do |installer_context|
   # We exclude all targets that contain `Test`, which might not work for some test targets
   # that doesn't include that word
   pods_targets = installer_context.umbrella_targets.reject { |target| target.cocoapods_target_label.include? 'Test' }
-  target_info = Hash.new
-  pods_targets.each do |pods_target|
-    puts "[Amimono] Pods target found: #{pods_target.cocoapods_target_label}"
-    target_info[pods_target] = installer_context.sandbox.target_support_files_dir pods_target.cocoapods_target_label
-  end
-
-  integrator = Amimono::Integrator.new(installer_context)
-  target_info.each do |pods_target, path|
-    integrator.update_xcconfigs(path)
-    puts "[Amimono] xcconfigs updated with filelist for target #{pods_target.cocoapods_target_label}"
-  end
-  integrator.update_build_phases(target_info.keys)
+  updater = Amimono::BuildPhasesUpdater.new
+  updater.update_build_phases(installer_context, pods_targets)
 end


### PR DESCRIPTION
`integrator` has being splitted into: `xcconfig_updater` and `build_phases_updater` because the [`UmbrellaTargetDescription`](http://www.rubydoc.info/gems/cocoapods/Pod/Installer/PostInstallHooksContext/UmbrellaTargetDescription) doesn't contain enough information to decide whether a pod should be built or not, so `xcconfig_updater` is now part of the `patcher` which has access to the [installer](http://www.rubydoc.info/gems/cocoapods/Pod/Installer/).

This should be good enough to support binary static frameworks, the real change is that instead of cleaning out the `-frameworks` linker flag in the xcconfig files, now we leave the binary Pods.

I haven't test this with binary dynamic frameworks.