### PR TITLE
Fix issue when binary framework name differs from Pod name

### DIFF
--- a/lib/cocoapods-amimono/xcconfig_updater.rb
+++ b/lib/cocoapods-amimono/xcconfig_updater.rb
@@ -14,7 +14,8 @@ module Amimono
         full_path = path + entry
         xcconfig = Xcodeproj::Config.new full_path
         # Clear the -frameworks flag
-        xcconfig.other_linker_flags[:frameworks] = Set.new(aggregated_target.pod_targets.reject(&:should_build?).map(&:name))
+        non_binary_frameworks = aggregated_target.pod_targets.select(&:should_build?).map(&:name)
+        xcconfig.other_linker_flags[:frameworks].reject! { |framework| non_binary_frameworks.include?(framework) }
         # Add -filelist flag instead, for each architecture
         archs.each do |arch|
           config_key = "OTHER_LDFLAGS[arch=#{arch}]"


### PR DESCRIPTION
This should fix https://github.com/Ruenzuo/cocoapods-amimono/issues/25.

Instead of creating a set of frameworks that don't have to be built, we remove the Pods that have to be built.