### PR TITLE
Fix issue when binary framework name differs from Pod name

### DIFF
--- a/lib/cocoapods-amimono/xcconfig_updater.rb
+++ b/lib/cocoapods-amimono/xcconfig_updater.rb
@@ -14,7 +14,7 @@ module Amimono
         full_path = path + entry
         xcconfig = Xcodeproj::Config.new full_path
         # Clear the -frameworks flag
-        non_binary_frameworks = aggregated_target.pod_targets.select(&:should_build?).map(&:name)
+        non_binary_frameworks = aggregated_target.pod_targets.select(&:should_build?).map(&:name).map { |n| n.gsub(/[+-]/,'_') }
         xcconfig.other_linker_flags[:frameworks].reject! { |framework| non_binary_frameworks.include?(framework) }
         # Add -filelist flag instead, for each architecture
         archs.each do |arch|


### PR DESCRIPTION
replace all `+` and `-` characters with `_` in  non_binary_frameworks names