### PR TITLE
Add proper handling of frameworks that aren't named the same as the pod + fix for resource bundles in vendored frameworks

### DIFF
--- a/lib/cocoapods-amimono/patcher.rb
+++ b/lib/cocoapods-amimono/patcher.rb
@@ -68,14 +68,8 @@ module Amimono
     # Copied over from https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/installer/xcode/pods_project_generator/aggregate_target_installer.rb#L115-L131
     # with some modifications to this particular use case
     def self.resources_by_config(aggregated_target, project)
-      library_targets = aggregated_target.pod_targets.reject do |pod_target|
-        # This reject doesn't matter much anymore. We have to process all targets because
-        # every single one requires frameworks and this workaround doesn't work with Pods
-        # that contains binaries
-        !pod_target.should_build?
-      end
       aggregated_target.user_build_configurations.keys.each_with_object({}) do |config, resources_by_config|
-        resources_by_config[config] = library_targets.flat_map do |library_target|
+        resources_by_config[config] = aggregated_target.pod_targets.flat_map do |library_target|
           next [] unless library_target.include_in_build_config?(aggregated_target.target_definition, config)
           resource_paths = library_target.file_accessors.flat_map do |accessor|
             accessor.resources.flat_map { |res| res.relative_path_from(project.path.dirname) }

--- a/lib/cocoapods-amimono/xcconfig_updater.rb
+++ b/lib/cocoapods-amimono/xcconfig_updater.rb
@@ -15,7 +15,6 @@ module Amimono
         xcconfig = Xcodeproj::Config.new full_path
         # Clear the -frameworks flag
         non_binary_frameworks = aggregated_target.pod_targets.select(&:should_build?).map { |t| t.product_name.gsub('.framework', '') }
-        STDERR.puts "#{non_binary_frameworks}"
         xcconfig.other_linker_flags[:frameworks].reject! { |framework| non_binary_frameworks.include?(framework) }
         # Add -filelist flag instead, for each architecture
         archs.each do |arch|

--- a/lib/cocoapods-amimono/xcconfig_updater.rb
+++ b/lib/cocoapods-amimono/xcconfig_updater.rb
@@ -14,7 +14,8 @@ module Amimono
         full_path = path + entry
         xcconfig = Xcodeproj::Config.new full_path
         # Clear the -frameworks flag
-        non_binary_frameworks = aggregated_target.pod_targets.select(&:should_build?).map(&:name)
+        non_binary_frameworks = aggregated_target.pod_targets.select(&:should_build?).map { |t| t.product_name.gsub('.framework', '') }
+        STDERR.puts "#{non_binary_frameworks}"
         xcconfig.other_linker_flags[:frameworks].reject! { |framework| non_binary_frameworks.include?(framework) }
         # Add -filelist flag instead, for each architecture
         archs.each do |arch|


### PR DESCRIPTION
Two issues were fixed: 

1. [#28](https://github.com/Ruenzuo/cocoapods-amimono/issues/28) - Originally reported to be due to pod names containing `-` or `+` in their name, the issue was not confined to them but included any pods that weren't named as their final product was, for example`leveldb-library` pod which produced `leveldb.framework`. The same problem also occured with platform variants of the same pod, for example `[podname]-iOS` and `[podname]-watchOS`. 


2. Another issue that I've encountered and fixed was that resource bundles from vendored frameworks did not get copied to the final bundle. an example for that would be the `TwitterKit` pod, which would compile and run well but cause a runtime error at initialization due to missing resource bundle.