### PR TITLE
Remove Test targets filter

### DIFF
--- a/lib/cocoapods-amimono/gem_version.rb
+++ b/lib/cocoapods-amimono/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsAmimono
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end

--- a/lib/cocoapods-amimono/patcher.rb
+++ b/lib/cocoapods-amimono/patcher.rb
@@ -16,7 +16,7 @@ module Amimono
     private
 
     def self.patch_xcconfig_files(installer)
-      aggregated_targets = installer.aggregate_targets.reject { |target| target.label.include? 'Test' }
+      aggregated_targets = installer.aggregate_targets
       updater = XCConfigUpdater.new(installer)
       aggregated_targets.each do |aggregated_target|
         puts "[Amimono] Pods target found: #{aggregated_target.label}"
@@ -27,7 +27,7 @@ module Amimono
     end
 
     def self.patch_vendored_build_settings(installer)
-      aggregated_targets = installer.aggregate_targets.reject { |target| target.label.include? 'Test' }
+      aggregated_targets = installer.aggregate_targets
       aggregated_targets.each do |aggregated_target|
         path = installer.sandbox.target_support_files_dir aggregated_target.label
         Dir.entries(path).select { |entry| entry.end_with? 'xcconfig' }.each do |entry|
@@ -46,7 +46,7 @@ module Amimono
 
     def self.patch_copy_resources_script(installer)
       project = installer.sandbox.project
-      aggregated_targets = installer.aggregate_targets.reject { |target| target.label.include? 'Test' }
+      aggregated_targets = installer.aggregate_targets
       aggregated_targets.each do |aggregated_target|
         path = aggregated_target.copy_resources_script_path
         resources = resources_by_config(aggregated_target, project)
@@ -58,7 +58,7 @@ module Amimono
 
     def self.patch_embed_frameworks_script(installer)
       project = installer.sandbox.project
-      aggregated_targets = installer.aggregate_targets.reject { |target| target.label.include? 'Test' }
+      aggregated_targets = installer.aggregate_targets
       aggregated_targets.each do |aggregated_target|
         path = aggregated_target.embed_frameworks_script_path
         frameworks = frameworks_by_config(aggregated_target, project)

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -2,9 +2,7 @@ require 'cocoapods-amimono/command'
 require 'cocoapods-amimono/build_phases_updater'
 
 Pod::HooksManager.register('cocoapods-amimono', :post_install) do |installer_context|
-  # We exclude all targets that contain `Test`, which might not work for some test targets
-  # that doesn't include that word
-  pods_targets = installer_context.umbrella_targets.reject { |target| target.cocoapods_target_label.include? 'Test' }
+  pods_targets = installer_context.umbrella_targets
   updater = Amimono::BuildPhasesUpdater.new
   updater.update_build_phases(installer_context, pods_targets)
 end


### PR DESCRIPTION
There is no obvious reason why amimono would not work for test targets. 
On the other side, iOS 9 simulator works better when we don't have tons of frameworks, including in Test targets. Especially for UI tests.